### PR TITLE
Change `coords` to `dims`

### DIFF
--- a/examples/Declarative_300hPa.py
+++ b/examples/Declarative_300hPa.py
@@ -51,7 +51,7 @@ vwnd = ds['v-component_of_wind_isobaric']
 wspd = mpcalc.wind_speed(uwnd, vwnd)
 
 # Place wind speed (wspd) into xarray dataset and attach needed attributes
-ds = ds.assign(wind_speed=(tuple(uwnd.coords)[:4], wspd.m,
+ds = ds.assign(wind_speed=(tuple(uwnd.dims)[:4], wspd.m,
                            {'grid_mapping': uwnd.attrs['grid_mapping'],
                             'units': str(wspd.units)}))
 


### PR DESCRIPTION
In adapting this code snippet to another example tonight, I discovered that `DataArray.coords` does not guarantee the same order as `dims`, resulting in a dimension mismatch when assigning. Changing to `DataArray.dims` fixed the issue for me.